### PR TITLE
ST5AS-111 Extend pagination to all collection endpoints in REST PSM

### DIFF
--- a/app/controllers/BaseController.java
+++ b/app/controllers/BaseController.java
@@ -1,0 +1,130 @@
+/*
+ * SysML v2 REST/HTTP Pilot Implementation
+ * Copyright (C) 2020  InterCAX LLC
+ * Copyright (C) 2020  California Institute of Technology ("Caltech")
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @license LGPL-3.0-or-later <http://spdx.org/licenses/LGPL-3.0-or-later>
+ */
+
+package controllers;
+
+import com.google.common.primitives.Bytes;
+import play.mvc.Controller;
+import play.mvc.Http;
+import play.mvc.Result;
+
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+public abstract class BaseController extends Controller {
+
+    protected static char CURSOR_SEPARATOR = '|';
+    protected static int DEFAULT_PAGE_SIZE = 100;
+
+    protected static UUID fromCursor(String cursor) throws IllegalArgumentException {
+        byte[] decoded = Base64.getUrlDecoder().decode(cursor);
+        int separatorIndex = Bytes.indexOf(decoded, (byte) CURSOR_SEPARATOR);
+        if (separatorIndex < 0) {
+            throw new IllegalArgumentException("Cursor separator missing");
+        }
+        return UUID.fromString(
+                new String(decoded, separatorIndex + 1, decoded.length - separatorIndex - 1)
+        );
+    }
+
+    protected static String toCursor(UUID id) throws IllegalArgumentException {
+        String unencoded = String.valueOf(Instant.now().toEpochMilli()) +
+                CURSOR_SEPARATOR +
+                id.toString();
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(unencoded.getBytes());
+    }
+
+    protected static class PageRequest {
+        private final UUID after;
+        private final UUID before;
+        private final int size;
+
+        private PageRequest(UUID after, UUID before, int size) {
+            this.after = after;
+            this.before = before;
+            this.size = size;
+        }
+
+        public UUID getAfter() {
+            return after;
+        }
+
+        public UUID getBefore() {
+            return before;
+        }
+
+        public int getSize() {
+            return size;
+        }
+
+        protected static PageRequest from(Http.Request request) throws IllegalArgumentException {
+            UUID after = Optional.ofNullable(request.getQueryString("page[after]"))
+                    .map(BaseController::fromCursor)
+                    //.map(UUID::fromString)
+                    .orElse(null);
+            UUID before = Optional.ofNullable(request.getQueryString("page[before]"))
+                    .map(BaseController::fromCursor)
+                    //.map(UUID::fromString)
+                    .orElse(null);
+            int size = Optional.ofNullable(request.getQueryString("page[size]"))
+                    .map(Integer::parseInt)
+                    .orElse(DEFAULT_PAGE_SIZE);
+            if (size <= 0) {
+                throw new IllegalArgumentException("Page size must be greater than zero.");
+            }
+            return new PageRequest(after, before, size);
+        }
+    }
+
+    protected Result paginateResult(Result result, int resultSize, Function<Integer, UUID> idAtIndex, Http.Request request, PageRequest pageRequest) {
+        if (resultSize > 0) {
+            boolean pageFull = resultSize == pageRequest.getSize();
+            boolean hasNext = pageFull || pageRequest.getBefore() != null;
+            boolean hasPrev = pageFull && pageRequest.getBefore() != null || pageRequest.getAfter() != null;
+            // hasPrev -> !pageFull || pageAfter != null
+            StringBuilder linkHeaderValueBuilder = new StringBuilder();
+            if (hasNext) {
+                linkHeaderValueBuilder.append(String.format("<http://%s%s?page[after]=%s&page[size]=%s>; rel=\"next\"",
+                        request.host(),
+                        request.path(),
+                        toCursor(idAtIndex.apply(resultSize - 1)),
+                        pageRequest.getSize()));
+                if (hasPrev) {
+                    linkHeaderValueBuilder.append(", ");
+                }
+            }
+            if (hasPrev) {
+                linkHeaderValueBuilder.append(String.format("<http://%s%s?page[before]=%s&page[size]=%s>; rel=\"prev\"",
+                        request.host(),
+                        request.path(),
+                        toCursor(idAtIndex.apply(0)),
+                        pageRequest.getSize()));
+            }
+            if (linkHeaderValueBuilder.length() > 0) {
+                result = result.withHeader("Link", linkHeaderValueBuilder.toString());
+            }
+        }
+        return result;
+    }
+}

--- a/app/controllers/QueryController.java
+++ b/app/controllers/QueryController.java
@@ -46,7 +46,7 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-public class QueryController extends Controller {
+public class QueryController extends BaseController {
 
     private final MetamodelProvider metamodelProvider;
     private final QueryService queryService;
@@ -108,9 +108,9 @@ public class QueryController extends Controller {
     private Result buildResponse(QueryService.QueryResults result, UUID projectId, Http.Request request) {
         List<Element> elements = result.getElements();
         AllowedPropertyFilter filter = result.getPropertyFilter();
-        boolean respondWithJsonLd = ElementController.respondWithJsonLd(request);
+        boolean respondWithJsonLd = respondWithJsonLd(request);
         JsonNode json = JacksonHelper.collectionToTree(elements.stream()
-                        .map(e -> respondWithJsonLd ? ElementController.adornMofObject(e, request, metamodelProvider, environment, projectId, result.getCommit().getId()) : e)
+                        .map(e -> respondWithJsonLd ? adornMofObject(e, request, metamodelProvider, environment, projectId, result.getCommit().getId()) : e)
                         .collect(Collectors.toSet()), Set.class,
                 respondWithJsonLd ? JsonLdMofObjectAdornment.class : metamodelProvider.getImplementationClass(Element.class),
                 filter != null ? () -> Json.mapper().copy().addMixIn(MofObject.class, DynamicFilterMixin.class) : Json::mapper,

--- a/app/controllers/QueryController.java
+++ b/app/controllers/QueryController.java
@@ -34,7 +34,6 @@ import org.omg.sysml.metamodel.MofObject;
 import org.omg.sysml.query.Query;
 import play.Environment;
 import play.libs.Json;
-import play.mvc.Controller;
 import play.mvc.Http;
 import play.mvc.Result;
 import play.mvc.Results;
@@ -59,23 +58,6 @@ public class QueryController extends BaseController {
         this.environment = environment;
     }
 
-    public Result byId(UUID id) {
-        Optional<Query> query = queryService.getById(id);
-        return query.map(m -> ok(Json.toJson(m))).orElseGet(Results::notFound);
-    }
-
-    public Result all() {
-        List<Query> queries = queryService.getAll();
-        return ok(JacksonHelper.collectionToTree(queries, List.class, metamodelProvider.getImplementationClass(Query.class)));
-    }
-
-    public Result create(Http.Request request) {
-        JsonNode requestBodyJson = request.body().asJson();
-        Query requestedObject = Json.fromJson(requestBodyJson, metamodelProvider.getImplementationClass(Query.class));
-        Optional<Query> response = queryService.create(requestedObject);
-        return response.map(e -> created(Json.toJson(e))).orElseGet(Results::internalServerError);
-    }
-
     public Result createWithProjectId(UUID projectId, Http.Request request) {
         JsonNode requestBodyJson = request.body().asJson();
         Query requestedObject = Json.fromJson(requestBodyJson, metamodelProvider.getImplementationClass(Query.class));
@@ -83,9 +65,20 @@ public class QueryController extends BaseController {
         return response.map(e -> created(Json.toJson(e))).orElseGet(Results::internalServerError);
     }
 
-    public Result byProject(UUID projectId) {
-        List<Query> queries = queryService.getByProjectId(projectId);
-        return ok(JacksonHelper.collectionToTree(queries, List.class, metamodelProvider.getImplementationClass(Query.class)));
+    public Result byProject(UUID projectId, Http.Request request) {
+        PageRequest pageRequest = PageRequest.from(request);
+        List<Query> queries = queryService.getByProjectId(projectId, pageRequest.getAfter(), pageRequest.getBefore(), pageRequest.getSize());
+        return Optional.of(queries)
+                .map(collection -> JacksonHelper.collectionToTree(collection, List.class, metamodelProvider.getImplementationClass(Query.class)))
+                .map(Results::ok)
+                .map(result -> paginateResult(
+                        result,
+                        queries.size(),
+                        idx -> queries.get(idx).getId(),
+                        request,
+                        pageRequest
+                ))
+                .orElseThrow();
     }
 
     public Result byProjectAndId(UUID projectId, UUID queryId) {
@@ -95,17 +88,17 @@ public class QueryController extends BaseController {
 
     public Result getQueryResultsByProjectIdQueryId(UUID projectId, UUID queryId, @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<UUID> commitId, Http.Request request) {
         QueryService.QueryResults result = queryService.getQueryResultsByProjectIdQueryId(projectId, queryId, commitId.orElse(null));
-        return buildResponse(result, projectId, request);
+        return buildResult(result, projectId, request);
     }
 
     public Result getQueryResultsByProjectIdQuery(UUID projectId, @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<UUID> commitId, Http.Request request) {
         JsonNode requestBodyJson = request.body().asJson();
         Query query = Json.fromJson(requestBodyJson, metamodelProvider.getImplementationClass(Query.class));
         QueryService.QueryResults result = queryService.getQueryResultsByProjectIdQuery(projectId, query, commitId.orElse(null));
-        return buildResponse(result, projectId, request);
+        return buildResult(result, projectId, request);
     }
 
-    private Result buildResponse(QueryService.QueryResults result, UUID projectId, Http.Request request) {
+    private Result buildResult(QueryService.QueryResults result, UUID projectId, Http.Request request) {
         List<Element> elements = result.getElements();
         AllowedPropertyFilter filter = result.getPropertyFilter();
         boolean respondWithJsonLd = respondWithJsonLd(request);

--- a/app/dao/CommitDao.java
+++ b/app/dao/CommitDao.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 
 public interface CommitDao extends Dao<Commit> {
 
-    List<Commit> findAllByProject(Project project);
+    List<Commit> findAllByProject(Project project, UUID after, UUID before, int maxResults);
 
     Optional<Commit> findByProjectAndId(Project project, UUID id);
 

--- a/app/dao/Dao.java
+++ b/app/dao/Dao.java
@@ -21,6 +21,7 @@
 
 package dao;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -34,6 +35,8 @@ public interface Dao<E> {
     Optional<E> findById(UUID id);
 
     List<E> findAll();
+
+    List<E> findAll(@Nullable UUID after, @Nullable UUID before, int maxResults);
 
     void delete(E entity);
 

--- a/app/dao/ElementDao.java
+++ b/app/dao/ElementDao.java
@@ -35,6 +35,8 @@ public interface ElementDao extends Dao<Element> {
 
     Optional<Element> findByCommitAndId(Commit commit, UUID id);
 
+    List<Element> findRootsByCommit(Commit commit, UUID after, UUID before, int maxResults);
+
     List<Element> findRootsByCommit(Commit commit);
 
     List<Element> findByCommitAndQuery(Commit commit, Query query);

--- a/app/dao/ElementDao.java
+++ b/app/dao/ElementDao.java
@@ -25,19 +25,18 @@ import org.omg.sysml.lifecycle.Commit;
 import org.omg.sysml.metamodel.Element;
 import org.omg.sysml.query.Query;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ElementDao extends Dao<Element> {
 
-    List<Element> findAllByCommit(Commit commit, UUID after, UUID before, int maxResults);
+    List<Element> findAllByCommit(Commit commit, @Nullable UUID after, @Nullable UUID before, int maxResults);
 
     Optional<Element> findByCommitAndId(Commit commit, UUID id);
 
-    List<Element> findRootsByCommit(Commit commit, UUID after, UUID before, int maxResults);
-
-    List<Element> findRootsByCommit(Commit commit);
+    List<Element> findRootsByCommit(Commit commit, @Nullable UUID after, @Nullable UUID before, int maxResults);
 
     List<Element> findByCommitAndQuery(Commit commit, Query query);
 }

--- a/app/dao/QueryDao.java
+++ b/app/dao/QueryDao.java
@@ -26,6 +26,7 @@ import org.omg.sysml.lifecycle.Project;
 import org.omg.sysml.metamodel.Element;
 import org.omg.sysml.query.Query;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -33,7 +34,7 @@ import java.util.UUID;
 
 public interface QueryDao extends Dao<Query> {
 
-    List<Query> findAllByProject(Project project);
+    List<Query> findAllByProject(Project project, @Nullable UUID after, @Nullable UUID before, int maxResults);
 
     Optional<Query> findByProjectAndId(Project project, UUID id);
 }

--- a/app/dao/RelationshipDao.java
+++ b/app/dao/RelationshipDao.java
@@ -24,10 +24,14 @@ package dao;
 import org.omg.sysml.lifecycle.Commit;
 import org.omg.sysml.metamodel.Element;
 import org.omg.sysml.metamodel.Relationship;
+import org.omg.sysml.utils.RelationshipDirection;
 
+import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 public interface RelationshipDao extends Dao<Relationship> {
 
-    Set<Relationship> findAllByCommitRelatedElement(Commit commit, Element relatedElement);
+    List<Relationship> findAllByCommitRelatedElement(Commit commit, Element relatedElement, RelationshipDirection direction, @Nullable UUID after, @Nullable UUID before, int maxResults);
 }

--- a/app/dao/impl/jpa/JpaCommitDao.java
+++ b/app/dao/impl/jpa/JpaCommitDao.java
@@ -211,7 +211,6 @@ public class JpaCommitDao extends SimpleJpaDao<Commit, CommitImpl> implements Co
             Paginated<TypedQuery<CommitImpl>> paginated = paginateQuery(after, before, maxResults, query, builder, em, root.get(CommitImpl_.id), where);
             List<Commit> result = paginated.get()
                     .getResultStream()
-                    .map(commit -> (Commit) commit)
                     .collect(Collectors.toList());
             if (paginated.isReversed()) {
                 Collections.reverse(result);

--- a/app/dao/impl/jpa/JpaCommitDao.java
+++ b/app/dao/impl/jpa/JpaCommitDao.java
@@ -39,6 +39,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
+import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
@@ -207,13 +208,12 @@ public class JpaCommitDao extends SimpleJpaDao<Commit, CommitImpl> implements Co
             Root<CommitImpl> root = query.from(CommitImpl.class);
             query.select(root);
             Expression<Boolean> where = builder.equal(root.get(CommitImpl_.containingProject), project);
-            PaginatedQuery<CommitImpl> paginatedQuery = paginateQuery(after, before, maxResults, query, builder, em, root.get(CommitImpl_.id), where);
-            List<Commit> result = paginatedQuery
-                    .getTypedQuery()
+            Paginated<TypedQuery<CommitImpl>> paginated = paginateQuery(after, before, maxResults, query, builder, em, root.get(CommitImpl_.id), where);
+            List<Commit> result = paginated.get()
                     .getResultStream()
                     .map(commit -> (Commit) commit)
                     .collect(Collectors.toList());
-            if (paginatedQuery.isReversed()) {
+            if (paginated.isReversed()) {
                 Collections.reverse(result);
             }
             return result;

--- a/app/dao/impl/jpa/JpaCommitDao.java
+++ b/app/dao/impl/jpa/JpaCommitDao.java
@@ -41,6 +41,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Root;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -113,21 +114,6 @@ public class JpaCommitDao extends SimpleJpaDao<Commit, CommitImpl> implements Co
                         }))
                 .collect(Collectors.toMap(change -> change.getIdentity().getId(), change -> Optional.ofNullable(change.getData()).orElse(tombstone)));
 
-        // Attempt #1 using a javassist proxy. Failed because Hibernate/JPA can't handle subclasses of Entities.
-/*        changeStream.get().map(ElementVersion::getData).filter(Objects::nonNull).map(JpaCommitDao::getBeanPropertyValues).flatMap(map -> map.values().stream()).flatMap(o -> o instanceof Collection ? ((Collection<?>) o).stream() : Stream.of(o)).filter(o -> o instanceof MofObject && o instanceof ProxyObject).map(o -> (MofObject & ProxyObject) o).forEach(mofProxy -> {
-            MofObject mof = identifierToMofMap.computeIfAbsent(mofProxy.getIdentifier(), identifier -> {
-                if (commit.getPreviousCommit() == null) {
-                    return tombstone;
-                }
-                return elementDao.findByCommitAndId(commit.getPreviousCommit(), identifier).map(element -> (MofObject) element).orElse(tombstone);
-            });
-            if (Objects.equals(mof, tombstone)) {
-                throw new IllegalArgumentException("Element with ID " + mofProxy.getIdentifier() + " not found.");
-            }
-            mofProxy.setHandler(new PassthroughMethodHandler(mof));
-            System.out.println("REFERENCE: " + mofProxy.getIdentifier());
-        });*/
-
         Function<MofObject, MofObject> reattachMofFunction = mof -> {
             MofObject reattachedMof = identifierToMofMap.computeIfAbsent(mof.getIdentifier(), identifier -> {
                 if (commit.getPreviousCommit() == null) {
@@ -188,15 +174,6 @@ public class JpaCommitDao extends SimpleJpaDao<Commit, CommitImpl> implements Co
                         })
                 );
 
- /*       changeStream.get().map(ElementVersion::getData).filter(Objects::nonNull).filter(element -> element instanceof BlockImpl).map(element -> (BlockImpl) element).forEach(block -> {
-            if (block.getOwner() instanceof MofObjectImpl) {
-                MofObjectImpl owner = (MofObjectImpl) block.getOwner();
-                if (owner.getIdentifier() != null) {
-                    block.setOwner((Element) identifierToMofMap.get(owner.getIdentifier()));
-                }
-            }
-        });*/
-
         return jpaManager.transact(em -> {
             commit.getChange().stream()
                     .map(ElementVersion::getData)
@@ -223,14 +200,23 @@ public class JpaCommitDao extends SimpleJpaDao<Commit, CommitImpl> implements Co
     }
 
     @Override
-    public List<Commit> findAllByProject(Project project) {
+    public List<Commit> findAllByProject(Project project, UUID after, UUID before, int maxResults) {
         return jpaManager.transact(em -> {
             CriteriaBuilder builder = em.getCriteriaBuilder();
             CriteriaQuery<CommitImpl> query = builder.createQuery(CommitImpl.class);
             Root<CommitImpl> root = query.from(CommitImpl.class);
-            query.select(root)
-                    .where(builder.equal(root.get(CommitImpl_.containingProject), project));
-            return em.createQuery(query).getResultStream().collect(Collectors.toList());
+            query.select(root);
+            Expression<Boolean> where = builder.equal(root.get(CommitImpl_.containingProject), project);
+            PaginatedQuery<CommitImpl> paginatedQuery = paginateQuery(after, before, maxResults, query, builder, em, root.get(CommitImpl_.id), where);
+            List<Commit> result = paginatedQuery
+                    .getTypedQuery()
+                    .getResultStream()
+                    .map(commit -> (Commit) commit)
+                    .collect(Collectors.toList());
+            if (paginatedQuery.isReversed()) {
+                Collections.reverse(result);
+            }
+            return result;
         });
     }
 
@@ -284,19 +270,4 @@ public class JpaCommitDao extends SimpleJpaDao<Commit, CommitImpl> implements Co
             return commit;
         });
     }
-
-/*    private static class PassthroughMethodHandler implements MethodHandler {
-
-        private final Object target;
-
-        protected PassthroughMethodHandler(Object target) {
-            this.target = target;
-        }
-
-        @Override
-        public Object invoke(Object self, Method thisMethod, Method proceed, Object[] args) throws Throwable {
-            //return thisMethod.invoke(target, args);
-            return target.getClass().getMethod(thisMethod.getName(), thisMethod.getParameterTypes()).invoke(target, args);
-        }
-    }*/
 }

--- a/app/dao/impl/jpa/JpaElementDao.java
+++ b/app/dao/impl/jpa/JpaElementDao.java
@@ -33,22 +33,20 @@ import org.omg.sysml.internal.impl.CommitIndexImpl_;
 import org.omg.sysml.lifecycle.Commit;
 import org.omg.sysml.lifecycle.ElementIdentity;
 import org.omg.sysml.lifecycle.ElementVersion;
-import org.omg.sysml.lifecycle.impl.ElementIdentityImpl;
-import org.omg.sysml.lifecycle.impl.ElementIdentityImpl_;
-import org.omg.sysml.lifecycle.impl.ElementVersionImpl;
-import org.omg.sysml.lifecycle.impl.ElementVersionImpl_;
+import org.omg.sysml.lifecycle.impl.*;
 import org.omg.sysml.metamodel.Element;
 import org.omg.sysml.metamodel.Relationship;
 import org.omg.sysml.metamodel.impl.MofObjectImpl;
 import org.omg.sysml.metamodel.impl.MofObjectImpl_;
 import org.omg.sysml.query.*;
+import org.omg.sysml.query.impl.QueryImpl;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityTransaction;
 import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
 import javax.persistence.criteria.*;
 import java.beans.PropertyDescriptor;
 import java.util.*;
@@ -71,11 +69,15 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
     };
 
     private final MetamodelProvider metamodelProvider;
+    private final Set<Class<?>> implementationClasses;
 
     @Inject
     public JpaElementDao(JPAManager jpaManager, MetamodelProvider metamodelProvider) {
         super(jpaManager);
         this.metamodelProvider = metamodelProvider;
+        this.implementationClasses = metamodelProvider.getAllImplementationClasses().stream()
+                .filter(Element.class::isAssignableFrom)
+                .collect(Collectors.toSet());
     }
 
     @Override
@@ -110,6 +112,27 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
     }
 
     @Override
+    public List<Element> findAll(@Nullable UUID after, @Nullable UUID before, int maxResults) {
+        return jpaManager.transact(em -> {
+            CriteriaBuilder builder = em.getCriteriaBuilder();
+            CriteriaQuery<MofObjectImpl> query = builder.createQuery(MofObjectImpl.class);
+            Root<MofObjectImpl> root = query.from(MofObjectImpl.class);
+            query.select(root);
+            Expression<Boolean> where = getTypeExpression(builder, root);
+            PaginatedQuery<MofObjectImpl> paginatedQuery = paginateQuery(after, before, maxResults, query, builder, em, root.get(MofObjectImpl_.identifier), where);
+            List<Element> result = paginatedQuery
+                    .getTypedQuery()
+                    .getResultStream()
+                    .map(o -> (Element) o)
+                    .collect(Collectors.toList());
+            if (paginatedQuery.isReversed()) {
+                Collections.reverse(result);
+            }
+            return result;
+        });
+    }
+
+    @Override
     public void deleteAll() {
         jpaManager.transact(em -> {
             CriteriaBuilder builder = em.getCriteriaBuilder();
@@ -122,10 +145,10 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
         });
     }
 
-    public List<Element> findAllByCommit(Commit commit, UUID after, UUID before, int maxResults) {
+    public List<Element> findAllByCommit(Commit commit, @Nullable UUID after, @Nullable UUID before, int maxResults) {
         return jpaManager.transact(em -> {
             // TODO Commit is detached at this point. This ternary mitigates by requerying for the Commit in this transaction. A better solution would be moving transaction handling up to service layer (supported by general wisdom) and optionally migrating to using Play's @Transactional/JPAApi. Pros would include removal of repetitive transaction handling at the DAO layer and ability to interface with multiple DAOs in the same transaction (consistent view). Cons include increased temptation to keep transaction open for longer than needed, e.g. during JSON serialization due to the convenience of @Transactional (deprecated in >= 2.8.x), and the service, a higher level of abstraction, becoming aware of transactions. An alternative would be DAO-to-DAO calls (generally discouraged) and delegating to non-transactional versions of methods.
-            Commit c = em.contains(commit) ? commit : em.find(metamodelProvider.getImplementationClass(Commit.class), commit.getId());
+            Commit c = em.contains(commit) ? commit : em.find(CommitImpl.class, commit.getId());
             CommitIndex commitIndex = getCommitIndex(c, em);
 
             CriteriaBuilder builder = em.getCriteriaBuilder();
@@ -133,30 +156,19 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
             Root<CommitIndexImpl> commitIndexRoot = query.from(CommitIndexImpl.class);
             SetJoin<CommitIndexImpl, ElementVersionImpl> workingElementVersionsJoin = commitIndexRoot.join(CommitIndexImpl_.workingElementVersions);
             Join<ElementVersionImpl, ElementIdentityImpl> elementIdentityJoin = workingElementVersionsJoin.join(ElementVersionImpl_.identity);
+            Path<UUID> idPath = elementIdentityJoin.get(ElementIdentityImpl_.id);
+            Expression<Boolean> where = builder.equal(commitIndexRoot.get(CommitIndexImpl_.id), commitIndex.getId());
             query.select(workingElementVersionsJoin);
-            Expression<Boolean> whereExpression = builder.equal(commitIndexRoot.get(CommitIndexImpl_.id), commitIndex.getId());
-            if (after != null) {
-                whereExpression = builder.and(whereExpression, builder.greaterThan(elementIdentityJoin.get(ElementIdentityImpl_.id), after));
-            }
-            if (before != null) {
-                whereExpression = builder.and(whereExpression, builder.lessThan(elementIdentityJoin.get(ElementIdentityImpl_.id), before));
-            }
-            query.where(whereExpression);
-            boolean flip = after == null && before != null;
-            Function<Path<UUID>, Order> orderFunction = flip ? builder::desc : builder::asc;
-            query.orderBy((orderFunction).apply(elementIdentityJoin.get(ElementIdentityImpl_.id)));
-            TypedQuery<ElementVersionImpl> typedQuery = em.createQuery(query);
-            if (maxResults >= 0) {
-                typedQuery.setMaxResults(maxResults);
-            }
-            List<Element> result = typedQuery
+            PaginatedQuery<ElementVersionImpl> paginatedQuery = paginateQuery(after, before, maxResults, query, builder, em, idPath, where);
+            List<Element> result = paginatedQuery
+                    .getTypedQuery()
                     .getResultStream()
                     .map(ElementVersion::getData)
                     .filter(mof -> mof instanceof Element)
                     .map(mof -> (Element) mof)
                     .map(PROXY_RESOLVER)
                     .collect(Collectors.toList());
-            if (flip) {
+            if (paginatedQuery.isReversed()) {
                 Collections.reverse(result);
             }
             return result;
@@ -167,7 +179,7 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
     public Optional<Element> findByCommitAndId(Commit commit, UUID id) {
         return jpaManager.transact(em -> {
             // TODO Commit is detached at this point. This ternary mitigates by requerying for the Commit in this transaction. A better solution would be moving transaction handling up to service layer (supported by general wisdom) and optionally migrating to using Play's @Transactional/JPAApi. Pros would include removal of repetitive transaction handling at the DAO layer and ability to interface with multiple DAOs in the same transaction (consistent view). Cons include increased temptation to keep transaction open for longer than needed, e.g. during JSON serialization due to the convenience of @Transactional (deprecated in >= 2.8.x), and the service, a higher level of abstraction, becoming aware of transactions. An alternative would be DAO-to-DAO calls (generally discouraged) and delegating to non-transactional versions of methods.
-            Commit c = em.contains(commit) ? commit : em.find(metamodelProvider.getImplementationClass(Commit.class), commit.getId());
+            Commit c = em.contains(commit) ? commit : em.find(CommitImpl.class, commit.getId());
             CommitIndex commitIndex = getCommitIndex(c, em);
 
             CriteriaBuilder builder = em.getCriteriaBuilder();
@@ -192,10 +204,15 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
     }
 
     @Override
+    public List<Element> findRootsByCommit(Commit commit, UUID after, UUID before, int maxResults) {
+        return null;
+    }
+
+    @Override
     public List<Element> findRootsByCommit(Commit commit) {
         return jpaManager.transact(em -> {
             // TODO Commit is detached at this point. This ternary mitigates by requerying for the Commit in this transaction. A better solution would be moving transaction handling up to service layer (supported by general wisdom) and optionally migrating to using Play's @Transactional/JPAApi. Pros would include removal of repetitive transaction handling at the DAO layer and ability to interface with multiple DAOs in the same transaction (consistent view). Cons include increased temptation to keep transaction open for longer than needed, e.g. during JSON serialization due to the convenience of @Transactional (deprecated in >= 2.8.x), and the service, a higher level of abstraction, becoming aware of transactions. An alternative would be DAO-to-DAO calls (generally discouraged) and delegating to non-transactional versions of methods.
-            Commit c = em.contains(commit) ? commit : em.find(metamodelProvider.getImplementationClass(Commit.class), commit.getId());
+            Commit c = em.contains(commit) ? commit : em.find(CommitImpl.class, commit.getId());
             return getCommitIndex(c, em).getWorkingElementVersions().stream()
                     .map(ElementVersion::getData)
                     .filter(mof -> (mof instanceof Element) && !(mof instanceof Relationship))
@@ -210,8 +227,8 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
     public List<Element> findByCommitAndQuery(Commit commit, Query query) {
         return jpaManager.transact(em -> {
             // TODO Commit is detached at this point. This ternary mitigates by requerying for the Commit in this transaction. A better solution would be moving transaction handling up to service layer (supported by general wisdom) and optionally migrating to using Play's @Transactional/JPAApi. Pros would include removal of repetitive transaction handling at the DAO layer and ability to interface with multiple DAOs in the same transaction (consistent view). Cons include increased temptation to keep transaction open for longer than needed, e.g. during JSON serialization due to the convenience of @Transactional (deprecated in >= 2.8.x), and the service, a higher level of abstraction, becoming aware of transactions. An alternative would be DAO-to-DAO calls (generally discouraged) and delegating to non-transactional versions of methods.
-            Commit c = em.contains(commit) ? commit : em.find(metamodelProvider.getImplementationClass(Commit.class), commit.getId());
-            Query q = query.getId() == null || em.contains(query) ? query : em.find(metamodelProvider.getImplementationClass(Query.class), query.getId());
+            Commit c = em.contains(commit) ? commit : em.find(CommitImpl.class, commit.getId());
+            Query q = query.getId() == null || em.contains(query) ? query : em.find(QueryImpl.class, query.getId());
             return getCommitIndex(c, em).getWorkingElementVersions().stream()
                     .filter(scope(q))
                     .map(ElementVersion::getData)
@@ -362,9 +379,9 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
     }
 
     private Expression<Boolean> getTypeExpression(CriteriaBuilder builder, Root<?> root) {
-        return builder.or(metamodelProvider.getAllImplementationClasses().stream()
-                .filter(Element.class::isAssignableFrom)
+        return builder.or(implementationClasses.stream()
                 .map(c -> builder.equal(root.type(), c))
-                .toArray(javax.persistence.criteria.Predicate[]::new));
+                .toArray(javax.persistence.criteria.Predicate[]::new)
+        );
     }
 }

--- a/app/dao/impl/jpa/JpaRelationshipDao.java
+++ b/app/dao/impl/jpa/JpaRelationshipDao.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.persistence.NoResultException;
+import javax.persistence.TypedQuery;
 import javax.persistence.criteria.*;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -95,13 +96,12 @@ public class JpaRelationshipDao extends JpaDao<Relationship> implements Relation
             Root<MofObjectImpl> root = query.from(MofObjectImpl.class);
             query.select(root);
             Expression<Boolean> where = getTypeExpression(builder, root);
-            PaginatedQuery<MofObjectImpl> paginatedQuery = paginateQuery(after, before, maxResults, query, builder, em, root.get(MofObjectImpl_.identifier), where);
-            List<Relationship> result = paginatedQuery
-                    .getTypedQuery()
+            Paginated<TypedQuery<MofObjectImpl>> paginated = paginateQuery(after, before, maxResults, query, builder, em, root.get(MofObjectImpl_.identifier), where);
+            List<Relationship> result = paginated.get()
                     .getResultStream()
                     .map(o -> (Relationship) o)
                     .collect(Collectors.toList());
-            if (paginatedQuery.isReversed()) {
+            if (paginated.isReversed()) {
                 Collections.reverse(result);
             }
             return result;

--- a/app/dao/impl/jpa/JpaRelationshipDao.java
+++ b/app/dao/impl/jpa/JpaRelationshipDao.java
@@ -26,32 +26,35 @@ import dao.RelationshipDao;
 import jpa.manager.JPAManager;
 import org.omg.sysml.lifecycle.Commit;
 import org.omg.sysml.lifecycle.ElementVersion;
+import org.omg.sysml.lifecycle.impl.CommitImpl;
 import org.omg.sysml.metamodel.Element;
 import org.omg.sysml.metamodel.Relationship;
 import org.omg.sysml.metamodel.impl.MofObjectImpl;
 import org.omg.sysml.metamodel.impl.MofObjectImpl_;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.persistence.NoResultException;
 import javax.persistence.criteria.*;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Singleton
 public class JpaRelationshipDao extends JpaDao<Relationship> implements RelationshipDao {
 
-    private final MetamodelProvider metamodelProvider;
     private final JpaElementDao elementDao;
+    private final Set<Class<?>> implementationClasses;
 
     @Inject
     public JpaRelationshipDao(JPAManager jpaManager, MetamodelProvider metamodelProvider, JpaElementDao elementDao) {
         super(jpaManager);
-        this.metamodelProvider = metamodelProvider;
+        this.implementationClasses = metamodelProvider
+                .getAllImplementationClasses()
+                .stream()
+                .filter(Relationship.class::isAssignableFrom)
+                .collect(Collectors.toSet());
         this.elementDao = elementDao;
     }
 
@@ -81,6 +84,27 @@ public class JpaRelationshipDao extends JpaDao<Relationship> implements Relation
             Root<MofObjectImpl> root = query.from(MofObjectImpl.class);
             query.select(root).where(getTypeExpression(builder, root));
             return em.createQuery(query).getResultStream().map(o -> (Relationship) o).collect(Collectors.toList());
+        });
+    }
+
+    @Override
+    public List<Relationship> findAll(@Nullable UUID after, @Nullable UUID before, int maxResults) {
+        return jpaManager.transact(em -> {
+            CriteriaBuilder builder = em.getCriteriaBuilder();
+            CriteriaQuery<MofObjectImpl> query = builder.createQuery(MofObjectImpl.class);
+            Root<MofObjectImpl> root = query.from(MofObjectImpl.class);
+            query.select(root);
+            Expression<Boolean> where = getTypeExpression(builder, root);
+            PaginatedQuery<MofObjectImpl> paginatedQuery = paginateQuery(after, before, maxResults, query, builder, em, root.get(MofObjectImpl_.identifier), where);
+            List<Relationship> result = paginatedQuery
+                    .getTypedQuery()
+                    .getResultStream()
+                    .map(o -> (Relationship) o)
+                    .collect(Collectors.toList());
+            if (paginatedQuery.isReversed()) {
+                Collections.reverse(result);
+            }
+            return result;
         });
     }
 
@@ -200,26 +224,25 @@ public class JpaRelationshipDao extends JpaDao<Relationship> implements Relation
 
             // Reverting to non-relational streaming
             // TODO Commit is detached at this point. This ternary mitigates by requerying for the Commit in this transaction. A better solution would be moving transaction handling up to service layer (supported by general wisdom) and optionally migrating to using Play's @Transactional/JPAApi. Pros would include removal of repetitive transaction handling at the DAO layer and ability to interface with multiple DAOs in the same transaction (consistent view). Cons include increased temptation to keep transaction open for longer than needed, e.g. during JSON serialization due to the convenience of @Transactional (deprecated in >= 2.8.x), and the service, a higher level of abstraction, becoming aware of transactions. An alternative would be DAO-to-DAO calls (generally discouraged) and delegating to non-transactional versions of methods.
-            Commit c = em.contains(commit) ? commit : em.find(metamodelProvider.getImplementationClass(Commit.class), commit.getId());
+            Commit c = em.contains(commit) ? commit : em.find(CommitImpl.class, commit.getId());
             return elementDao.getCommitIndex(c, em).getWorkingElementVersions().stream()
                     .map(ElementVersion::getData).filter(mof -> mof instanceof Relationship)
                     .map(mof -> (Relationship) mof)
-                    .filter(relationship -> Stream.concat(relationship.getSource().stream(), relationship.getTarget().stream()).map(Element::getIdentifier)
-                            .anyMatch(id -> id.equals(relatedElement.getIdentifier())))
+                    .filter(relationship ->
+                            Stream.concat(relationship.getSource().stream(), relationship.getTarget().stream())
+                                    .map(Element::getIdentifier)
+                                    .anyMatch(id -> id.equals(relatedElement.getIdentifier()))
+                    )
                     .map(JpaElementDao.PROXY_RESOLVER)
                     .map(mof -> (Relationship) mof)
                     .collect(Collectors.toSet());
         });
     }
 
-    private Stream<Class<?>> getTypeStream() {
-        return metamodelProvider.getAllImplementationClasses().stream()
-                .filter(Relationship.class::isAssignableFrom);
-    }
-
     private Expression<Boolean> getTypeExpression(CriteriaBuilder builder, Root<?> root) {
-        return builder.or(getTypeStream()
+        return builder.or(implementationClasses.stream()
                 .map(c -> builder.equal(root.type(), c))
-                .toArray(Predicate[]::new));
+                .toArray(Predicate[]::new)
+        );
     }
 }

--- a/app/dao/impl/jpa/SimpleJpaDao.java
+++ b/app/dao/impl/jpa/SimpleJpaDao.java
@@ -24,6 +24,7 @@ package dao.impl.jpa;
 import jpa.manager.JPAManager;
 
 import javax.persistence.NoResultException;
+import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
@@ -84,11 +85,10 @@ public class SimpleJpaDao<I, C extends I> extends JpaDao<I> {
             CriteriaQuery<I> query = (CriteriaQuery<I>) builder.createQuery(clazz);
             Root<C> root = query.from(clazz);
             query.select(root);
-            PaginatedQuery<I> paginatedQuery = paginateQuery(after, before, maxResults, query, builder, em, root.get(idAttribute));
-            List<I> result = paginatedQuery
-                    .getTypedQuery()
+            Paginated<TypedQuery<I>> paginated = paginateQuery(after, before, maxResults, query, builder, em, root.get(idAttribute));
+            List<I> result = paginated.get()
                     .getResultList();
-            if (paginatedQuery.isReversed()) {
+            if (paginated.isReversed()) {
                 Collections.reverse(result);
             }
             return result;

--- a/app/services/BaseService.java
+++ b/app/services/BaseService.java
@@ -23,6 +23,7 @@ package services;
 
 import dao.Dao;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -37,6 +38,10 @@ public class BaseService<I, D extends Dao<I>> {
 
     public List<I> getAll() {
         return dao.findAll();
+    }
+
+    public List<I> getAll(@Nullable UUID after, @Nullable UUID before, int maxResults) {
+        return dao.findAll(after, before, maxResults);
     }
 
     public Optional<I> getById(UUID id) {

--- a/app/services/CommitService.java
+++ b/app/services/CommitService.java
@@ -24,6 +24,7 @@ package services;
 import dao.CommitDao;
 import dao.ProjectDao;
 import org.omg.sysml.lifecycle.Commit;
+import org.omg.sysml.lifecycle.Project;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -48,19 +49,24 @@ public class CommitService extends BaseService<Commit, CommitDao> {
     }
 
     public Optional<Commit> create(UUID projectId, Commit commit) {
-        commit.setContainingProject(projectDao.findById(projectId).orElseThrow(() -> new IllegalArgumentException("Project " + projectId + " not found.")));
+        commit.setContainingProject(projectDao.findById(projectId)
+                .orElseThrow(() -> new IllegalArgumentException("Project " + projectId + " not found.")));
         return create(commit);
     }
 
-    public List<Commit> getByProjectId(UUID projectId) {
-        return projectDao.findById(projectId).map(dao::findAllByProject).orElse(Collections.emptyList());
+    public List<Commit> getByProjectId(UUID projectId, UUID after, UUID before, int maxResults) {
+        return projectDao.findById(projectId)
+                .map(project -> dao.findAllByProject(project, after, before, maxResults))
+                .orElse(Collections.emptyList());
     }
 
     public Optional<Commit> getByProjectIdAndId(UUID projectId, UUID commitId) {
-        return projectDao.findById(projectId).flatMap(project -> dao.findByProjectAndIdResolved(project, commitId));
+        return projectDao.findById(projectId)
+                .flatMap(project -> dao.findByProjectAndIdResolved(project, commitId));
     }
 
     public Optional<Commit> getHeadByProjectId(UUID projectId) {
-        return projectDao.findById(projectId).flatMap(dao::findHeadByProject);
+        return projectDao.findById(projectId)
+                .flatMap(dao::findHeadByProject);
     }
 }

--- a/app/services/ElementService.java
+++ b/app/services/ElementService.java
@@ -70,13 +70,6 @@ public class ElementService extends BaseService<Element, ElementDao> {
                 .flatMap(commit -> dao.findByCommitAndId(commit, elementId));
     }
 
-    public List<Element> getRootsByProjectIdCommitId(UUID projectId, UUID commitId) {
-        return projectDao.findById(projectId)
-                .flatMap(project -> commitDao.findByProjectAndId(project, commitId))
-                .map(dao::findRootsByCommit)
-                .orElse(Collections.emptyList());
-    }
-
     public List<Element> getRootsByProjectIdCommitId(UUID projectId, UUID commitId, @Nullable UUID after, @Nullable UUID before, int maxResults) {
         return projectDao.findById(projectId)
                 .flatMap(project -> commitDao.findByProjectAndId(project, commitId))

--- a/app/services/ElementService.java
+++ b/app/services/ElementService.java
@@ -27,6 +27,7 @@ import dao.ProjectDao;
 import dao.QueryDao;
 import org.omg.sysml.metamodel.Element;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.Collections;
@@ -39,14 +40,12 @@ public class ElementService extends BaseService<Element, ElementDao> {
 
     private final ProjectDao projectDao;
     private final CommitDao commitDao;
-    private final QueryDao queryDao;
 
     @Inject
-    public ElementService(ElementDao elementDao, ProjectDao projectDao, CommitDao commitDao, QueryDao queryDao) {
+    public ElementService(ElementDao elementDao, ProjectDao projectDao, CommitDao commitDao) {
         super(elementDao);
         this.projectDao = projectDao;
         this.commitDao = commitDao;
-        this.queryDao = queryDao;
     }
 
     public Optional<Element> create(Element element) {
@@ -58,7 +57,7 @@ public class ElementService extends BaseService<Element, ElementDao> {
                 .flatMap(m -> dao.findByCommitAndId(m, elementId));
     }
 
-    public List<Element> getElementsByProjectIdCommitId(UUID projectId, UUID commitId, UUID after, UUID before, int maxResults) {
+    public List<Element> getElementsByProjectIdCommitId(UUID projectId, UUID commitId, @Nullable UUID after, @Nullable UUID before, int maxResults) {
         return projectDao.findById(projectId)
                 .flatMap(project -> commitDao.findByProjectAndId(project, commitId))
                 .map(commit -> dao.findAllByCommit(commit, after, before, maxResults))
@@ -75,6 +74,13 @@ public class ElementService extends BaseService<Element, ElementDao> {
         return projectDao.findById(projectId)
                 .flatMap(project -> commitDao.findByProjectAndId(project, commitId))
                 .map(dao::findRootsByCommit)
+                .orElse(Collections.emptyList());
+    }
+
+    public List<Element> getRootsByProjectIdCommitId(UUID projectId, UUID commitId, @Nullable UUID after, @Nullable UUID before, int maxResults) {
+        return projectDao.findById(projectId)
+                .flatMap(project -> commitDao.findByProjectAndId(project, commitId))
+                .map(commit -> dao.findRootsByCommit(commit, after, before, maxResults))
                 .orElse(Collections.emptyList());
     }
 }

--- a/app/services/QueryService.java
+++ b/app/services/QueryService.java
@@ -64,8 +64,10 @@ public class QueryService extends BaseService<Query, QueryDao> {
         return create(query);
     }
 
-    public List<Query> getByProjectId(UUID projectId) {
-        return projectDao.findById(projectId).map(dao::findAllByProject).orElse(Collections.emptyList());
+    public List<Query> getByProjectId(UUID projectId, @Nullable UUID after, @Nullable UUID before, int maxResults) {
+        return projectDao.findById(projectId)
+                .map(project -> dao.findAllByProject(project, after, before, maxResults))
+                .orElse(Collections.emptyList());
     }
 
     public Optional<Query> getByProjectIdAndId(UUID projectId, UUID queryId) {

--- a/app/services/RelationshipService.java
+++ b/app/services/RelationshipService.java
@@ -31,12 +31,10 @@ import org.omg.sysml.metamodel.Element;
 import org.omg.sysml.metamodel.Relationship;
 import org.omg.sysml.utils.RelationshipDirection;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Singleton
@@ -58,25 +56,9 @@ public class RelationshipService extends BaseService<Relationship, RelationshipD
         return relationship.getIdentifier() != null ? dao.update(relationship) : dao.persist(relationship);
     }
 
-    public Set<Relationship> getRelationshipsByProjectCommitRelatedElement(UUID projectId, UUID commitId, UUID relatedElementId, RelationshipDirection direction) {
+    public List<Relationship> getRelationshipsByProjectCommitRelatedElement(UUID projectId, UUID commitId, UUID relatedElementId, RelationshipDirection direction, @Nullable UUID after, @Nullable UUID before, int maxResults) {
         Commit commit = projectDao.findById(projectId).flatMap(project -> commitDao.findByProjectAndId(project, commitId)).orElseThrow(() -> new IllegalArgumentException("Commit " + commitId + " not found."));
         Element relatedElement = elementDao.findByCommitAndId(commit, relatedElementId).orElseThrow(() -> new IllegalArgumentException("Element " + relatedElementId + " not found."));
-        Set<Relationship> allRelationships = dao.findAllByCommitRelatedElement(commit, relatedElement);
-        Set<Relationship> results = allRelationships;
-        if (RelationshipDirection.OUT.equals(direction)) {
-            results = allRelationships.stream()
-                    .filter(r -> r.getSource().stream()
-                            .anyMatch(e -> Objects.equals(e.getIdentifier(), relatedElementId))
-                    )
-                    .collect(Collectors.toSet());
-        } else if (RelationshipDirection.IN.equals(direction)) {
-            results = allRelationships.stream()
-                    .filter(r -> r.getTarget().stream()
-                            .anyMatch(e -> Objects.equals(e.getIdentifier(), relatedElementId))
-                    )
-                    .collect(Collectors.toSet());
-        }
-
-        return results;
+        return dao.findAllByCommitRelatedElement(commit, relatedElement, direction, after, before, maxResults);
     }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -7,12 +7,12 @@
 GET         /                                                                                      controllers.HomeController.index
 
 # Project endpoints
-GET         /projects                                                                              controllers.ProjectController.all()
+GET         /projects                                                                              controllers.ProjectController.all(request : Request)
 POST        /projects                                                                              controllers.ProjectController.create(request : Request)
 GET         /projects/:projectId                                                                   controllers.ProjectController.byId(projectId : java.util.UUID)
 
 # Commit endpoints
-GET         /projects/:projectId/commits                                                           controllers.CommitController.byProject(projectId : java.util.UUID)
+GET         /projects/:projectId/commits                                                           controllers.CommitController.byProject(projectId : java.util.UUID, request : Request)
 POST        /projects/:projectId/commits                                                           controllers.CommitController.createWithProjectId(projectId : java.util.UUID, request : Request)
 GET         /projects/:projectId/commits/:commitId                                                 controllers.CommitController.byProjectAndId(projectId : java.util.UUID, commitId : java.util.UUID)
 GET         /projects/:projectId/head                                                              controllers.CommitController.headByProject(projectId : java.util.UUID)

--- a/conf/routes
+++ b/conf/routes
@@ -26,7 +26,7 @@ GET         /projects/:projectId/commits/:commitId/roots                        
 GET         /projects/:projectId/commits/:commitId/elements/:relatedElementId/relationships        controllers.RelationshipController.getRelationshipsByProjectIdCommitIdRelatedElementId(projectId : java.util.UUID, commitId : java.util.UUID, relatedElementId : java.util.UUID, direction : java.util.Optional[String], request : Request)
 
 # Query endpoints
-GET         /projects/:projectId/queries                                                           controllers.QueryController.byProject(projectId : java.util.UUID)
+GET         /projects/:projectId/queries                                                           controllers.QueryController.byProject(projectId : java.util.UUID, request : Request)
 POST        /projects/:projectId/queries                                                           controllers.QueryController.createWithProjectId(projectId : java.util.UUID, request : Request)
 GET         /projects/:projectId/queries/:queryId                                                  controllers.QueryController.byProjectAndId(projectId : java.util.UUID, queryId : java.util.UUID)
 GET         /projects/:projectId/queries/:queryId/results                                          controllers.QueryController.getQueryResultsByProjectIdQueryId(projectId : java.util.UUID, queryId : java.util.UUID, commitId : java.util.Optional[java.util.UUID], request : Request)

--- a/public/swagger/openapi.yaml
+++ b/public/swagger/openapi.yaml
@@ -412,6 +412,22 @@ paths:
         default: 'both'
         required: false
     get:
+      parameters:
+        - name: page[after]
+          in: query
+          description: Page after
+          type: string
+          required: false
+        - name: page[before]
+          in: query
+          description: Page before
+          type: string
+          required: false
+        - name: page[size]
+          in: query
+          description: Page size
+          type: integer
+          required: false
       tags:
         - Relationship
       operationId: getRelationshipsByProjectCommitRelatedElement

--- a/public/swagger/openapi.yaml
+++ b/public/swagger/openapi.yaml
@@ -343,6 +343,22 @@ paths:
         format: uuid
         required: true
     get:
+      parameters:
+        - name: page[after]
+          in: query
+          description: Page after
+          type: string
+          required: false
+        - name: page[before]
+          in: query
+          description: Page before
+          type: string
+          required: false
+        - name: page[size]
+          in: query
+          description: Page size
+          type: integer
+          required: false
       tags:
         - Element
       operationId: getRootsByProjectCommit

--- a/public/swagger/openapi.yaml
+++ b/public/swagger/openapi.yaml
@@ -13,6 +13,22 @@ tags:
 paths:
   /projects:
     get:
+      parameters:
+        - name: page[after]
+          in: query
+          description: Page after
+          type: string
+          required: false
+        - name: page[before]
+          in: query
+          description: Page before
+          type: string
+          required: false
+        - name: page[size]
+          in: query
+          description: Page size
+          type: integer
+          required: false
       tags:
         - Project
       operationId: getProjects
@@ -94,6 +110,22 @@ paths:
         format: uuid
         required: true
     get:
+      parameters:
+        - name: page[after]
+          in: query
+          description: Page after
+          type: string
+          required: false
+        - name: page[before]
+          in: query
+          description: Page before
+          type: string
+          required: false
+        - name: page[size]
+          in: query
+          description: Page size
+          type: integer
+          required: false
       tags:
         - Commit
       operationId: getCommitsByProject

--- a/public/swagger/openapi.yaml
+++ b/public/swagger/openapi.yaml
@@ -457,6 +457,22 @@ paths:
         format: uuid
         required: true
     get:
+      parameters:
+        - name: page[after]
+          in: query
+          description: Page after
+          type: string
+          required: false
+        - name: page[before]
+          in: query
+          description: Page before
+          type: string
+          required: false
+        - name: page[size]
+          in: query
+          description: Page size
+          type: integer
+          required: false
       tags:
         - Query
       operationId: getQueriesByProject


### PR DESCRIPTION
Includes all endpoints, e.g. `getProjects`, `getCommitsByProject`, `getRootsByProjectCommit`, `getQueriesByProject`, except for endpoints that return QueryResult collections, e.g. `getQueryResultsByProjectIdQueryId` as those will likely have to be handled distinctly and have been split off to https://openmbee.atlassian.net/browse/ST5AS-115.