### PR TITLE
ST5AS-201 Add option to exclude data/elements from ProjectUsages

### DIFF
--- a/app/controllers/ElementController.java
+++ b/app/controllers/ElementController.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public final class ElementController extends JsonLdController<Element, DataJsonLdAdorner.Parameters> {
 
     private final ElementService elementService;
@@ -49,20 +50,20 @@ public final class ElementController extends JsonLdController<Element, DataJsonL
         this.adorner = new DataJsonLdAdorner<>(metamodelProvider, environment, INLINE_JSON_LD_CONTEXT);
     }
 
-    public Result getElementsByProjectIdCommitId(UUID projectId, UUID commitId, Request request) {
+    public Result getElementsByProjectIdCommitId(UUID projectId, UUID commitId, Optional<Boolean> excludeUsed, Request request) {
         PageRequest pageRequest = PageRequest.from(request);
-        List<Element> elements = elementService.getElementsByProjectIdCommitId(projectId, commitId, pageRequest.getAfter(), pageRequest.getBefore(), pageRequest.getSize());
+        List<Element> elements = elementService.getElementsByProjectIdCommitId(projectId, commitId, excludeUsed.orElse(false), pageRequest.getAfter(), pageRequest.getBefore(), pageRequest.getSize());
         return buildPaginatedResult(elements, projectId, commitId, request, pageRequest);
     }
 
-    public Result getElementByProjectIdCommitIdElementId(UUID projectId, UUID commitId, UUID elementId, Request request) {
-        Optional<Element> element = elementService.getElementByProjectIdCommitIdElementId(projectId, commitId, elementId);
+    public Result getElementByProjectIdCommitIdElementId(UUID projectId, UUID commitId, UUID elementId, Optional<Boolean> excludeUsed, Request request) {
+        Optional<Element> element = elementService.getElementByProjectIdCommitIdElementId(projectId, commitId, elementId, excludeUsed.orElse(false));
         return buildResult(element.orElse(null), request, new DataJsonLdAdorner.Parameters(projectId, commitId));
     }
 
-    public Result getRootsByProjectIdCommitId(UUID projectId, UUID commitId, Request request) {
+    public Result getRootsByProjectIdCommitId(UUID projectId, UUID commitId, Optional<Boolean> excludeUsed, Request request) {
         PageRequest pageRequest = PageRequest.from(request);
-        List<Element> roots = elementService.getRootsByProjectIdCommitId(projectId, commitId, pageRequest.getAfter(), pageRequest.getBefore(), pageRequest.getSize());
+        List<Element> roots = elementService.getRootsByProjectIdCommitId(projectId, commitId, excludeUsed.orElse(false), pageRequest.getAfter(), pageRequest.getBefore(), pageRequest.getSize());
         return buildPaginatedResult(roots, projectId, commitId, request, pageRequest);
     }
 

--- a/app/controllers/RelationshipController.java
+++ b/app/controllers/RelationshipController.java
@@ -51,7 +51,8 @@ public final class RelationshipController extends JsonLdController<Relationship,
         this.adorner = new DataJsonLdAdorner<>(metamodelProvider, environment, INLINE_JSON_LD_CONTEXT);
     }
 
-    public Result getRelationshipsByProjectIdCommitIdRelatedElementId(UUID projectId, UUID commitId, UUID relatedElementId, @SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<String> direction, Request request) {
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public Result getRelationshipsByProjectIdCommitIdRelatedElementId(UUID projectId, UUID commitId, UUID relatedElementId, Optional<String> direction, Optional<Boolean> excludeUsed, Request request) {
         PageRequest pageRequest = PageRequest.from(request);
         RelationshipDirection relationshipDirection = direction
                 .flatMap(d -> Arrays.stream(RelationshipDirection.values())
@@ -64,6 +65,7 @@ public final class RelationshipController extends JsonLdController<Relationship,
                 commitId,
                 relatedElementId,
                 relationshipDirection,
+                excludeUsed.orElse(false),
                 pageRequest.getAfter(),
                 pageRequest.getBefore(),
                 pageRequest.getSize()

--- a/app/dao/ElementDao.java
+++ b/app/dao/ElementDao.java
@@ -32,11 +32,11 @@ import java.util.UUID;
 
 public interface ElementDao extends Dao<Element> {
 
-    List<Element> findAllByCommit(Commit commit, @Nullable UUID after, @Nullable UUID before, int maxResults);
+    List<Element> findAllByCommit(Commit commit, boolean excludeUsed, @Nullable UUID after, @Nullable UUID before, int maxResults);
 
-    Optional<Element> findByCommitAndId(Commit commit, UUID id);
+    Optional<Element> findByCommitAndId(Commit commit, UUID id, boolean excludeUsed);
 
-    List<Element> findRootsByCommit(Commit commit, @Nullable UUID after, @Nullable UUID before, int maxResults);
+    List<Element> findRootsByCommit(Commit commit, boolean excludeUsed, @Nullable UUID after, @Nullable UUID before, int maxResults);
 
     Optional<Element> findByCommitAndQualifiedName(Commit commit, String qualifiedName);
 }

--- a/app/dao/RelationshipDao.java
+++ b/app/dao/RelationshipDao.java
@@ -33,5 +33,5 @@ import java.util.UUID;
 
 public interface RelationshipDao extends Dao<Relationship> {
 
-    List<Relationship> findAllByCommitRelatedElement(Commit commit, Element relatedElement, RelationshipDirection direction, @Nullable UUID after, @Nullable UUID before, int maxResults);
+    List<Relationship> findAllByCommitRelatedElement(Commit commit, Element relatedElement, RelationshipDirection direction, boolean excludeUsed, @Nullable UUID after, @Nullable UUID before, int maxResults);
 }

--- a/app/dao/impl/jpa/JpaCommitDao.java
+++ b/app/dao/impl/jpa/JpaCommitDao.java
@@ -89,7 +89,7 @@ public class JpaCommitDao extends SimpleJpaDao<Commit, CommitImpl> implements Co
                 (fnData, fnCommit) -> {
                     UUID id = fnData.getId();
                     // TODO change to dataDao
-                    return elementDao.findByCommitAndId(fnCommit, id)
+                    return elementDao.findByCommitAndId(fnCommit, id, false)
                             .orElseThrow(() -> new NoSuchElementException(
                                     String.format("Element with %s %s not found", IDENTITY_FIELD, id)
                             ));
@@ -122,7 +122,7 @@ public class JpaCommitDao extends SimpleJpaDao<Commit, CommitImpl> implements Co
                     if (fnData.getId() != null) {
                         UUID id = fnData.getId();
                         // TODO change to dataDao
-                        return elementDao.findByCommitAndId(fnCommit, id)
+                        return elementDao.findByCommitAndId(fnCommit, id, false)
                                 .orElseThrow(() -> new NoSuchElementException(
                                         String.format("Element with %s %s not found", IDENTITY_FIELD, id)
                                 ));

--- a/app/dao/impl/jpa/JpaElementDao.java
+++ b/app/dao/impl/jpa/JpaElementDao.java
@@ -27,10 +27,8 @@ import dao.ElementDao;
 import jpa.manager.JPAManager;
 import org.omg.sysml.internal.CommitDataVersionIndex;
 import org.omg.sysml.internal.CommitNamedElementIndex;
-import org.omg.sysml.internal.impl.CommitDataVersionIndexImpl;
-import org.omg.sysml.internal.impl.CommitDataVersionIndexImpl_;
-import org.omg.sysml.internal.impl.CommitNamedElementIndexImpl;
-import org.omg.sysml.internal.impl.CommitNamedElementIndexImpl_;
+import org.omg.sysml.internal.WorkingDataVersion;
+import org.omg.sysml.internal.impl.*;
 import org.omg.sysml.lifecycle.Commit;
 import org.omg.sysml.lifecycle.DataVersion;
 import org.omg.sysml.lifecycle.impl.*;
@@ -78,7 +76,7 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
                     getTypeExpression(builder, root)
             ));
             try {
-                return Optional.of((Element) em.createQuery(query).getSingleResult());
+                return Optional.of(em.createQuery(query).getSingleResult());
             } catch (NoResultException e) {
                 return Optional.empty();
             }
@@ -131,7 +129,7 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
         });
     }
 
-    public List<Element> findAllByCommit(Commit commit, @Nullable UUID after, @Nullable UUID before, int maxResults) {
+    public List<Element> findAllByCommit(Commit commit, boolean excludeUsed, @Nullable UUID after, @Nullable UUID before, int maxResults) {
         return jpaManager.transact(em -> {
             // TODO Commit is detached at this point. This ternary mitigates by requerying for the Commit in this transaction. A better solution would be moving transaction handling up to service layer (supported by general wisdom) and optionally migrating to using Play's @Transactional/JPAApi. Pros would include removal of repetitive transaction handling at the DAO layer and ability to interface with multiple DAOs in the same transaction (consistent view). Cons include increased temptation to keep transaction open for longer than needed, e.g. during JSON serialization due to the convenience of @Transactional (deprecated in >= 2.8.x), and the service, a higher level of abstraction, becoming aware of transactions. An alternative would be DAO-to-DAO calls (generally discouraged) and delegating to non-transactional versions of methods.
             Commit c = em.contains(commit) ? commit : em.find(CommitImpl.class, commit.getId());
@@ -140,11 +138,15 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
             CriteriaBuilder builder = em.getCriteriaBuilder();
             CriteriaQuery<DataVersionImpl> query = builder.createQuery(DataVersionImpl.class);
             Root<CommitDataVersionIndexImpl> commitIndexRoot = query.from(CommitDataVersionIndexImpl.class);
-            SetJoin<CommitDataVersionIndexImpl, DataVersionImpl> workingDataVersionsJoin = commitIndexRoot.join(CommitDataVersionIndexImpl_.workingDataVersion);
-            Join<DataVersionImpl, DataIdentityImpl> dataIdentityJoin = workingDataVersionsJoin.join(DataVersionImpl_.identity);
+            SetJoin<CommitDataVersionIndexImpl, WorkingDataVersionImpl> workingDataVersionJoin = commitIndexRoot.join(CommitDataVersionIndexImpl_.workingDataVersion);
+            Join<WorkingDataVersionImpl, DataVersionImpl> dataVersionJoin = workingDataVersionJoin.join(WorkingDataVersionImpl_.dataVersion);
+            Join<DataVersionImpl, DataIdentityImpl> dataIdentityJoin = dataVersionJoin.join(DataVersionImpl_.identity);
             Path<UUID> idPath = dataIdentityJoin.get(DataIdentityImpl_.id);
             Expression<Boolean> where = builder.equal(commitIndexRoot.get(CommitDataVersionIndexImpl_.id), commitIndex.getId());
-            query.select(workingDataVersionsJoin);
+            if (excludeUsed) {
+                where = builder.and(where, builder.isNull(workingDataVersionJoin.get(WorkingDataVersionImpl_.source)));
+            }
+            query.select(dataVersionJoin);
             Paginated<TypedQuery<DataVersionImpl>> paginated = paginateQuery(after, before, maxResults, query, builder, em, idPath, where);
             List<Element> result = paginated.get()
                     .getResultStream()
@@ -161,7 +163,7 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
     }
 
     @Override
-    public Optional<Element> findByCommitAndId(Commit commit, UUID id) {
+    public Optional<Element> findByCommitAndId(Commit commit, UUID id, boolean excludeUsed) {
         return jpaManager.transact(em -> {
             // TODO Commit is detached at this point. This ternary mitigates by requerying for the Commit in this transaction. A better solution would be moving transaction handling up to service layer (supported by general wisdom) and optionally migrating to using Play's @Transactional/JPAApi. Pros would include removal of repetitive transaction handling at the DAO layer and ability to interface with multiple DAOs in the same transaction (consistent view). Cons include increased temptation to keep transaction open for longer than needed, e.g. during JSON serialization due to the convenience of @Transactional (deprecated in >= 2.8.x), and the service, a higher level of abstraction, becoming aware of transactions. An alternative would be DAO-to-DAO calls (generally discouraged) and delegating to non-transactional versions of methods.
             Commit c = em.contains(commit) ? commit : em.find(CommitImpl.class, commit.getId());
@@ -170,12 +172,17 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
             CriteriaBuilder builder = em.getCriteriaBuilder();
             CriteriaQuery<DataVersionImpl> query = builder.createQuery(DataVersionImpl.class);
             Root<CommitDataVersionIndexImpl> commitIndexRoot = query.from(CommitDataVersionIndexImpl.class);
-            SetJoin<CommitDataVersionIndexImpl, DataVersionImpl> workingDataVersionsJoin = commitIndexRoot.join(CommitDataVersionIndexImpl_.workingDataVersion);
-            Join<DataVersionImpl, DataIdentityImpl> identityJoin = workingDataVersionsJoin.join(DataVersionImpl_.identity);
-            query.select(workingDataVersionsJoin).where(
+            SetJoin<CommitDataVersionIndexImpl, WorkingDataVersionImpl> workingDataVersionJoin = commitIndexRoot.join(CommitDataVersionIndexImpl_.workingDataVersion);
+            Join<WorkingDataVersionImpl, DataVersionImpl> dataVersionJoin = workingDataVersionJoin.join(WorkingDataVersionImpl_.dataVersion);
+            Join<DataVersionImpl, DataIdentityImpl> dataIdentityJoin = dataVersionJoin.join(DataVersionImpl_.identity);
+            Expression<Boolean> where = builder.and(
                     builder.equal(commitIndexRoot.get(CommitDataVersionIndexImpl_.id), commitIndex.getId()),
-                    builder.equal(identityJoin.get(DataIdentityImpl_.id), id)
+                    builder.equal(dataIdentityJoin.get(DataIdentityImpl_.id), id)
             );
+            if (excludeUsed) {
+                where = builder.and(where, builder.isNull(workingDataVersionJoin.get(WorkingDataVersionImpl_.source)));
+            }
+            query.select(dataVersionJoin).where(where);
             try {
                 return Optional.of(em.createQuery(query).getSingleResult())
                         .map(DataVersion::getPayload)
@@ -189,11 +196,13 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
     }
 
     @Override
-    public List<Element> findRootsByCommit(Commit commit, @Nullable UUID after, @Nullable UUID before, int maxResults) {
+    public List<Element> findRootsByCommit(Commit commit, boolean excludeUsed, @Nullable UUID after, @Nullable UUID before, int maxResults) {
         return jpaManager.transact(em -> {
             // TODO Commit is detached at this point. This ternary mitigates by requerying for the Commit in this transaction. A better solution would be moving transaction handling up to service layer (supported by general wisdom) and optionally migrating to using Play's @Transactional/JPAApi. Pros would include removal of repetitive transaction handling at the DAO layer and ability to interface with multiple DAOs in the same transaction (consistent view). Cons include increased temptation to keep transaction open for longer than needed, e.g. during JSON serialization due to the convenience of @Transactional (deprecated in >= 2.8.x), and the service, a higher level of abstraction, becoming aware of transactions. An alternative would be DAO-to-DAO calls (generally discouraged) and delegating to non-transactional versions of methods.
             Commit c = em.contains(commit) ? commit : em.find(CommitImpl.class, commit.getId());
             Stream<Element> stream = dataDao.getCommitIndex(c, em).getWorkingDataVersion().stream()
+                    .filter(working -> !excludeUsed || working.getSource() == null)
+                    .map(WorkingDataVersion::getDataVersion)
                     .map(DataVersion::getPayload)
                     .filter(data -> (data instanceof Element) && !(data instanceof Relationship))
                     .map(data -> (Element) data)
@@ -244,6 +253,7 @@ public class JpaElementDao extends JpaDao<Element> implements ElementDao {
 
     protected Stream<Element> streamWorkingElements(Commit commit, EntityManager em) {
         return dataDao.getCommitIndex(commit, em).getWorkingDataVersion().stream()
+                .map(WorkingDataVersion::getDataVersion)
                 .map(DataVersion::getPayload)
                 .filter(data -> data instanceof Element)
                 .map(data -> (Element) data);

--- a/app/org/omg/sysml/internal/CommitDataVersionIndex.java
+++ b/app/org/omg/sysml/internal/CommitDataVersionIndex.java
@@ -24,18 +24,19 @@ package org.omg.sysml.internal;
 
 import org.omg.sysml.lifecycle.Commit;
 import org.omg.sysml.lifecycle.DataVersion;
+import org.omg.sysml.record.Record;
+import org.omg.sysml.record.impl.RecordImpl;
 
 import java.util.Set;
 import java.util.UUID;
 
-public interface CommitDataVersionIndex {
-    UUID getId();
+public interface CommitDataVersionIndex extends Record {
 
     Commit getCommit();
 
     void setCommit(Commit commit);
 
-    Set<DataVersion> getWorkingDataVersion();
+    Set<WorkingDataVersion> getWorkingDataVersion();
 
-    void setWorkingDataVersion(Set<DataVersion> workingDataVersion);
+    void setWorkingDataVersion(Set<WorkingDataVersion> workingDataVersion);
 }

--- a/app/org/omg/sysml/internal/CommitNamedElementIndex.java
+++ b/app/org/omg/sysml/internal/CommitNamedElementIndex.java
@@ -2,12 +2,12 @@ package org.omg.sysml.internal;
 
 import org.omg.sysml.lifecycle.Commit;
 import org.omg.sysml.metamodel.Element;
+import org.omg.sysml.record.Record;
 
 import java.util.Map;
 import java.util.UUID;
 
-public interface CommitNamedElementIndex {
-    UUID getId();
+public interface CommitNamedElementIndex extends Record {
 
     Commit getCommit();
 

--- a/app/org/omg/sysml/internal/WorkingDataVersion.java
+++ b/app/org/omg/sysml/internal/WorkingDataVersion.java
@@ -1,0 +1,16 @@
+package org.omg.sysml.internal;
+
+import org.omg.sysml.data.ProjectUsage;
+import org.omg.sysml.lifecycle.DataVersion;
+import org.omg.sysml.record.Record;
+
+public interface WorkingDataVersion extends Record {
+
+    ProjectUsage getSource();
+
+    void setSource(ProjectUsage commit);
+
+    DataVersion getDataVersion();
+
+    void setDataVersion(DataVersion dataVersion);
+}

--- a/app/org/omg/sysml/internal/impl/CommitDataVersionIndexImpl.java
+++ b/app/org/omg/sysml/internal/impl/CommitDataVersionIndexImpl.java
@@ -23,12 +23,14 @@
 package org.omg.sysml.internal.impl;
 
 import org.omg.sysml.internal.CommitDataVersionIndex;
+import org.omg.sysml.internal.WorkingDataVersion;
 import org.omg.sysml.lifecycle.Commit;
 import org.omg.sysml.lifecycle.DataVersion;
 import org.omg.sysml.lifecycle.impl.CommitImpl;
 import org.omg.sysml.lifecycle.impl.DataVersionImpl;
 
 import javax.persistence.*;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -36,13 +38,14 @@ import java.util.UUID;
 public class CommitDataVersionIndexImpl implements CommitDataVersionIndex {
     private UUID id;
     private Commit commit;
-    private Set<DataVersion> workingDataVersion;
+    private Set<WorkingDataVersion> workingDataVersion;
 
     @Id
     public UUID getId() {
         return id;
     }
 
+    @Override
     public void setId(UUID id) {
         this.id = id;
     }
@@ -61,13 +64,13 @@ public class CommitDataVersionIndexImpl implements CommitDataVersionIndex {
     }
 
     @Override
-    @ManyToMany(targetEntity = DataVersionImpl.class, fetch = FetchType.LAZY)
-    public Set<DataVersion> getWorkingDataVersion() {
+    @ManyToMany(targetEntity = WorkingDataVersionImpl.class, fetch = FetchType.LAZY)
+    public Set<WorkingDataVersion> getWorkingDataVersion() {
         return workingDataVersion;
     }
 
     @Override
-    public void setWorkingDataVersion(Set<DataVersion> workingDataVersion) {
+    public void setWorkingDataVersion(Set<WorkingDataVersion> workingDataVersion) {
         this.workingDataVersion = workingDataVersion;
     }
 }

--- a/app/org/omg/sysml/internal/impl/WorkingDataVersionImpl.java
+++ b/app/org/omg/sysml/internal/impl/WorkingDataVersionImpl.java
@@ -1,0 +1,42 @@
+package org.omg.sysml.internal.impl;
+
+import org.omg.sysml.data.ProjectUsage;
+import org.omg.sysml.data.impl.ProjectUsageImpl;
+import org.omg.sysml.internal.WorkingDataVersion;
+import org.omg.sysml.lifecycle.DataVersion;
+import org.omg.sysml.lifecycle.impl.CommitImpl;
+import org.omg.sysml.lifecycle.impl.DataVersionImpl;
+import org.omg.sysml.record.impl.RecordImpl;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ManyToOne;
+
+@Entity(name = "WorkingDataVersion")
+public class WorkingDataVersionImpl extends RecordImpl implements WorkingDataVersion {
+
+    private ProjectUsage source;
+    private DataVersion dataVersion;
+
+    @Override
+    @ManyToOne(targetEntity = ProjectUsageImpl.class, fetch = FetchType.LAZY)
+    public ProjectUsage getSource() {
+        return source;
+    }
+
+    @Override
+    public void setSource(ProjectUsage source) {
+        this.source = source;
+    }
+
+    @Override
+    @ManyToOne(targetEntity = DataVersionImpl.class, fetch = FetchType.LAZY)
+    public DataVersion getDataVersion() {
+        return dataVersion;
+    }
+
+    @Override
+    public void setDataVersion(DataVersion dataVersion) {
+        this.dataVersion = dataVersion;
+    }
+}

--- a/app/services/ElementService.java
+++ b/app/services/ElementService.java
@@ -51,28 +51,28 @@ public class ElementService extends BaseService<Element, ElementDao> {
         return element.getElementId() != null ? dao.update(element) : dao.persist(element);
     }
 
-    public Optional<Element> getElementByCommitIdElementId(UUID commitId, UUID elementId) {
+    public Optional<Element> getElementByCommitIdElementId(UUID commitId, UUID elementId, boolean excludeUsed) {
         return commitDao.findById(commitId)
-                .flatMap(m -> dao.findByCommitAndId(m, elementId));
+                .flatMap(m -> dao.findByCommitAndId(m, elementId, excludeUsed));
     }
 
-    public List<Element> getElementsByProjectIdCommitId(UUID projectId, UUID commitId, @Nullable UUID after, @Nullable UUID before, int maxResults) {
+    public List<Element> getElementsByProjectIdCommitId(UUID projectId, UUID commitId, boolean excludeUsed, @Nullable UUID after, @Nullable UUID before, int maxResults) {
         return projectDao.findById(projectId)
                 .flatMap(project -> commitDao.findByProjectAndId(project, commitId))
-                .map(commit -> dao.findAllByCommit(commit, after, before, maxResults))
+                .map(commit -> dao.findAllByCommit(commit, excludeUsed, after, before, maxResults))
                 .orElse(Collections.emptyList());
     }
 
-    public Optional<Element> getElementByProjectIdCommitIdElementId(UUID projectId, UUID commitId, UUID elementId) {
+    public Optional<Element> getElementByProjectIdCommitIdElementId(UUID projectId, UUID commitId, UUID elementId, boolean excludeUsed) {
         return projectDao.findById(projectId)
                 .flatMap(project -> commitDao.findByProjectAndId(project, commitId))
-                .flatMap(commit -> dao.findByCommitAndId(commit, elementId));
+                .flatMap(commit -> dao.findByCommitAndId(commit, elementId, excludeUsed));
     }
 
-    public List<Element> getRootsByProjectIdCommitId(UUID projectId, UUID commitId, @Nullable UUID after, @Nullable UUID before, int maxResults) {
+    public List<Element> getRootsByProjectIdCommitId(UUID projectId, UUID commitId, boolean excludeUsed, @Nullable UUID after, @Nullable UUID before, int maxResults) {
         return projectDao.findById(projectId)
                 .flatMap(project -> commitDao.findByProjectAndId(project, commitId))
-                .map(commit -> dao.findRootsByCommit(commit, after, before, maxResults))
+                .map(commit -> dao.findRootsByCommit(commit, excludeUsed, after, before, maxResults))
                 .orElse(Collections.emptyList());
     }
 

--- a/app/services/RelationshipService.java
+++ b/app/services/RelationshipService.java
@@ -57,9 +57,9 @@ public class RelationshipService extends BaseService<Relationship, RelationshipD
         return relationship.getElementId() != null ? dao.update(relationship) : dao.persist(relationship);
     }
 
-    public List<Relationship> getRelationshipsByProjectCommitRelatedElement(UUID projectId, UUID commitId, UUID relatedElementId, RelationshipDirection direction, @Nullable UUID after, @Nullable UUID before, int maxResults) {
+    public List<Relationship> getRelationshipsByProjectCommitRelatedElement(UUID projectId, UUID commitId, UUID relatedElementId, RelationshipDirection direction, boolean excludeUsed, @Nullable UUID after, @Nullable UUID before, int maxResults) {
         Commit commit = projectDao.findById(projectId).flatMap(project -> commitDao.findByProjectAndId(project, commitId)).orElseThrow(() -> new IllegalArgumentException("Commit " + commitId + " not found"));
-        Element relatedElement = elementDao.findByCommitAndId(commit, relatedElementId).orElseThrow(() -> new IllegalArgumentException("Element " + relatedElementId + " not found"));
-        return dao.findAllByCommitRelatedElement(commit, relatedElement, direction, after, before, maxResults);
+        Element relatedElement = elementDao.findByCommitAndId(commit, relatedElementId, excludeUsed).orElseThrow(() -> new IllegalArgumentException("Element " + relatedElementId + " not found"));
+        return dao.findAllByCommitRelatedElement(commit, relatedElement, direction, excludeUsed, after, before, maxResults);
     }
 }

--- a/conf/META-INF/persistence.xml
+++ b/conf/META-INF/persistence.xml
@@ -13,6 +13,7 @@
         <class>org.omg.sysml.internal.impl</class>
         <class>org.omg.sysml.internal.impl.CommitDataVersionIndexImpl</class>
         <class>org.omg.sysml.internal.impl.CommitNamedElementIndexImpl</class>
+        <class>org.omg.sysml.internal.impl.WorkingDataVersionImpl</class>
 
         <class>org.omg.sysml.lifecycle.impl</class>
         <class>org.omg.sysml.lifecycle.impl.BranchImpl</class>

--- a/conf/routes
+++ b/conf/routes
@@ -31,12 +31,12 @@ POST          /projects/:projectId/commits                                      
 GET           /projects/:projectId/commits/:commitId                                                 controllers.CommitController.getCommitByProjectAndId(projectId : java.util.UUID, commitId : java.util.UUID, request : Request)
 
 # Element endpoints
-GET           /projects/:projectId/commits/:commitId/elements                                        controllers.ElementController.getElementsByProjectIdCommitId(projectId : java.util.UUID, commitId : java.util.UUID, request : Request)
-GET           /projects/:projectId/commits/:commitId/elements/:elementId                             controllers.ElementController.getElementByProjectIdCommitIdElementId(projectId : java.util.UUID, commitId : java.util.UUID, elementId : java.util.UUID, request : Request)
-GET           /projects/:projectId/commits/:commitId/roots                                           controllers.ElementController.getRootsByProjectIdCommitId(projectId : java.util.UUID, commitId : java.util.UUID, request : Request)
+GET           /projects/:projectId/commits/:commitId/elements                                        controllers.ElementController.getElementsByProjectIdCommitId(projectId : java.util.UUID, commitId : java.util.UUID, excludeUsed : java.util.Optional[java.lang.Boolean], request : Request)
+GET           /projects/:projectId/commits/:commitId/elements/:elementId                             controllers.ElementController.getElementByProjectIdCommitIdElementId(projectId : java.util.UUID, commitId : java.util.UUID, elementId : java.util.UUID, excludeUsed : java.util.Optional[java.lang.Boolean], request : Request)
+GET           /projects/:projectId/commits/:commitId/roots                                           controllers.ElementController.getRootsByProjectIdCommitId(projectId : java.util.UUID, commitId : java.util.UUID, excludeUsed : java.util.Optional[java.lang.Boolean], request : Request)
 
 # Relationship endpoints
-GET           /projects/:projectId/commits/:commitId/elements/:relatedElementId/relationships        controllers.RelationshipController.getRelationshipsByProjectIdCommitIdRelatedElementId(projectId : java.util.UUID, commitId : java.util.UUID, relatedElementId : java.util.UUID, direction : java.util.Optional[String], request : Request)
+GET           /projects/:projectId/commits/:commitId/elements/:relatedElementId/relationships        controllers.RelationshipController.getRelationshipsByProjectIdCommitIdRelatedElementId(projectId : java.util.UUID, commitId : java.util.UUID, relatedElementId : java.util.UUID, direction : java.util.Optional[String], excludeUsed : java.util.Optional[java.lang.Boolean], request : Request)
 
 # Query endpoints
 GET           /projects/:projectId/queries                                                           controllers.QueryController.getQueriesByProject(projectId : java.util.UUID, request : Request)

--- a/generated/org/omg/sysml/internal/impl/CommitDataVersionIndexImpl_.java
+++ b/generated/org/omg/sysml/internal/impl/CommitDataVersionIndexImpl_.java
@@ -6,14 +6,13 @@ import javax.persistence.metamodel.SetAttribute;
 import javax.persistence.metamodel.SingularAttribute;
 import javax.persistence.metamodel.StaticMetamodel;
 import org.omg.sysml.lifecycle.impl.CommitImpl;
-import org.omg.sysml.lifecycle.impl.DataVersionImpl;
 
 @Generated(value = "org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor")
 @StaticMetamodel(CommitDataVersionIndexImpl.class)
 public abstract class CommitDataVersionIndexImpl_ {
 
 	public static volatile SingularAttribute<CommitDataVersionIndexImpl, CommitImpl> commit;
-	public static volatile SetAttribute<CommitDataVersionIndexImpl, DataVersionImpl> workingDataVersion;
+	public static volatile SetAttribute<CommitDataVersionIndexImpl, WorkingDataVersionImpl> workingDataVersion;
 	public static volatile SingularAttribute<CommitDataVersionIndexImpl, UUID> id;
 
 	public static final String COMMIT = "commit";

--- a/generated/org/omg/sysml/internal/impl/WorkingDataVersionImpl_.java
+++ b/generated/org/omg/sysml/internal/impl/WorkingDataVersionImpl_.java
@@ -1,0 +1,20 @@
+package org.omg.sysml.internal.impl;
+
+import javax.annotation.processing.Generated;
+import javax.persistence.metamodel.SingularAttribute;
+import javax.persistence.metamodel.StaticMetamodel;
+import org.omg.sysml.data.impl.ProjectUsageImpl;
+import org.omg.sysml.lifecycle.impl.DataVersionImpl;
+
+@Generated(value = "org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor")
+@StaticMetamodel(WorkingDataVersionImpl.class)
+public abstract class WorkingDataVersionImpl_ extends org.omg.sysml.record.impl.RecordImpl_ {
+
+	public static volatile SingularAttribute<WorkingDataVersionImpl, DataVersionImpl> dataVersion;
+	public static volatile SingularAttribute<WorkingDataVersionImpl, ProjectUsageImpl> source;
+
+	public static final String DATA_VERSION = "dataVersion";
+	public static final String SOURCE = "source";
+
+}
+

--- a/public/swagger/openapi.yaml
+++ b/public/swagger/openapi.yaml
@@ -543,22 +543,28 @@ paths:
         type: string
         format: uuid
         required: true
-      - name: page[after]
-        in: query
-        description: Page after
-        type: string
-        required: false
-      - name: page[before]
-        in: query
-        description: Page before
-        type: string
-        required: false
-      - name: page[size]
-        in: query
-        description: Page size
-        type: integer
-        required: false
     get:
+      parameters:
+        - name: excludeUsed
+          in: query
+          description: Exclude elements from ProjectUsages
+          type: boolean
+          required: false
+        - name: page[after]
+          in: query
+          description: Page after
+          type: string
+          required: false
+        - name: page[before]
+          in: query
+          description: Page before
+          type: string
+          required: false
+        - name: page[size]
+          in: query
+          description: Page size
+          type: integer
+          required: false
       tags:
         - Element
       operationId: getElementsByProjectCommit
@@ -602,6 +608,12 @@ paths:
         format: uuid
         required: true
     get:
+      parameters:
+        - name: excludeUsed
+          in: query
+          description: Exclude elements from ProjectUsages
+          type: boolean
+          required: false
       tags:
         - Element
       operationId: getElementByProjectCommitId
@@ -638,6 +650,11 @@ paths:
         required: true
     get:
       parameters:
+        - name: excludeUsed
+          in: query
+          description: Exclude elements from ProjectUsages
+          type: boolean
+          required: false
         - name: page[after]
           in: query
           description: Page after
@@ -695,18 +712,23 @@ paths:
         type: string
         format: uuid
         required: true
-      - name: direction
-        in: query
-        description: Filter for relationships that are incoming (in), outgoing (out), or both relative to the related element
-        type: string
-        enum:
-          - 'in'
-          - 'out'
-          - 'both'
-        default: 'both'
-        required: false
     get:
       parameters:
+        - name: direction
+          in: query
+          description: Filter for relationships that are incoming (in), outgoing (out), or both relative to the related element
+          type: string
+          enum:
+            - 'in'
+            - 'out'
+            - 'both'
+          default: 'both'
+          required: false
+        - name: excludeUsed
+          in: query
+          description: Exclude relationships from ProjectUsages
+          type: boolean
+          required: false
         - name: page[after]
           in: query
           description: Page after


### PR DESCRIPTION
Operations related to returning `Data`, e.g. `Element(s)`, include `Data` from `ProjectUsages`. This applies to the following endpoints:

* `GET           /projects/:projectId/commits/:commitId/elements`
* `GET           /projects/:projectId/commits/:commitId/elements/:elementId`
* `GET           /projects/:projectId/commits/:commitId/roots`
* `GET           /projects/:projectId/commits/:commitId/elements/:relatedElementId/relationships`

Some specialized use cases would like the ability for these operations to provide only the direct / “owned” `Data`. To satisfy these needs, an option has been added to these operations to `excludeUsed`.