### PR TITLE
fix: ST5AS-207 Project PUT

### DIFF
--- a/app/jackson/JpaIdentityDeserializer.java
+++ b/app/jackson/JpaIdentityDeserializer.java
@@ -52,16 +52,18 @@ public abstract class JpaIdentityDeserializer<T> extends StdDeserializer<T> {
         if (p.currentToken() != JsonToken.START_OBJECT) {
             throw new JsonParseException(p, "Expected START_OBJECT. Received " + p.getCurrentName() + ".");
         }
+        T t = null;
         JsonToken token;
         while ((token = p.nextToken()) != null && token != JsonToken.END_OBJECT) {
-            if (token == JsonToken.FIELD_NAME && isIdentityField(p.getCurrentName())) {
-                if (p.nextToken() == null) {
+            if (t == null && token == JsonToken.FIELD_NAME && isIdentityField(p.getCurrentName())) {
+                token = p.nextToken();
+                if (token == null) {
                     throw new JsonParseException(p, "No value for identity field.");
                 }
-                return deserializeFromIdentity(p);
+                t = deserializeFromIdentity(p);
             }
         }
-        return null;
+        return t;
     }
 
     @Override

--- a/app/jackson/RecordSerialization.java
+++ b/app/jackson/RecordSerialization.java
@@ -66,14 +66,13 @@ public class RecordSerialization {
         }
 
         @Override
-        @SuppressWarnings("unchecked")
         protected R deserializeFromIdentity(JsonParser parser) throws IOException {
             UUID id = UUID.fromString(parser.getText());
-            Record record = getEntityManager().find(getRecordClass(), id);
+            R record = getEntityManager().find(getRecordClass(), id);
             if (record == null) {
                 throw new IOException(new EntityNotFoundException("Record " + id + " not found."));
             }
-            return (R) record;
+            return record;
         }
     }
 


### PR DESCRIPTION
Fixed the bug that resulted in `description` and `name` not being persisted as provided. This actually had to do with the deserialization of `defaultBranch` resulting in succeeding fields being ignored. The same request, but with `description` and `name` specified before `defaultBranch`, worked fine which is why it avoided detection until now. For example, the following request worked fine, because `defaultBranch` was the last key.

```json
{
  "@id": "32fb596e-6ebc-4a3a-ae01-8ae932465759",
  "@type": "Project",
  "description": "Test project for verifying PUT",
  "name": "Test Project 1a",
  "defaultBranch": {
    "@id": "43b82c7b-222c-4ed6-89f4-94a4868541c3"
  }
}
```

Resolves #72.