### PR TITLE
GH-130:  ~Switch CDN providers to avoid unpkg.com CDN issue

### DIFF
--- a/public/docs/focused/index.html
+++ b/public/docs/focused/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 characters -->
-  <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/rapidoc/dist/rapidoc-min.js"></script>
 </head>
 <body>
 <rapi-doc

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8"> <!-- Important: rapi-doc uses utf8 characters -->
-  <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/rapidoc/dist/rapidoc-min.js"></script>
 </head>
 <body>
 <rapi-doc


### PR DESCRIPTION
More permanent fix for my previously suggested internal manual workaround for issue reported in #130:  

> workaround:
> 1.  In Chrome, open DevTools
> 2.  Click on Sources tab
> 3.  Expand the tree on the left sidebar as shown under **Deployed > top > servername > docs > docs/**
> 4.  R-click on 📄  docs and select **Override content** (see 1st screenshot below)
![image](https://github.com/user-attachments/assets/43bc01fc-8b34-4529-8269-b2ce71ea6303)
> 5.  You should see an editing pane in the right side (see 2nd screenshot below)
![image](https://github.com/user-attachments/assets/47d67f47-2df8-4422-9067-b316401fc57e)
> 6.  Replace the highlighted text on L5 with a different JS NPM CDN, ex:  https://cdn.jsdelivr.net/npm/rapidoc@9.3.8/dist/rapidoc-min.js
> 7.  Hit **⌘-S(ave)**, you should see the * in `index.html` go away indicating modifications saved
> 8.  Reload page
> 9.  You should see it render now ✅  (see 3rd screenshot)
![image](https://github.com/user-attachments/assets/ed6f66fd-a2df-4440-88d8-c0855418bc2c)

Tested with local build (in Dev mode) on MacOS 12 and verified it worked ✅ 
![image](https://github.com/user-attachments/assets/87c2e71e-88b2-4235-b9d4-03c3f4c46b5e)

ℹ️ N.B, to test locally I did have to implement the workaround for the issue reported in #118, specifically https://github.com/Systems-Modeling/SysML-v2-API-Services/issues/118#issuecomment-2479655329.  

(I can create a separate PR for that to fix this on AARM64 ("M1") architecture machines) 